### PR TITLE
Change to list only SNS subscriptions by subscribed topic

### DIFF
--- a/cform/ecs.yaml
+++ b/cform/ecs.yaml
@@ -397,7 +397,7 @@ Resources:
                 - ecs:ListTasks
                 - ecs:DescribeTasks
                 - sns:Publish
-                - sns:ListSubscriptions
+                - sns:ListSubscriptionsByTopic
                 Resource: "*"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/code/index.py
+++ b/code/index.py
@@ -158,7 +158,9 @@ def lambda_handler(event, context):
 
             # If tasks are still running...
             if tasksRunning == 1:
-                response = snsClient.list_subscriptions()
+                response = snsClient.list_subscriptions_by_topic(
+                    TopicArn=TopicArn
+                )
                 for key in response['Subscriptions']:
                     logger.info("Endpoint %s AND TopicArn %s and protocol %s ",key['Endpoint'], key['TopicArn'],
                                                                                   key['Protocol'])


### PR DESCRIPTION
Update to loop over just the subscribed SNS topic in the event.

Also by default `list_subscriptions()` returns 100 subscriptions at a time. So if you have more than 100, it might not find the correct subscription. 